### PR TITLE
Fix isnan(double) is ambiguous

### DIFF
--- a/qtcontrols/src/eplotlight/eplotlight_base.cpp
+++ b/qtcontrols/src/eplotlight/eplotlight_base.cpp
@@ -608,9 +608,9 @@ bool EPlotLightBase::adjustYScale(double percent, bool do_replot)
         /* y */
 //        printf("\e[1;31m curve %s min val max val %f %f\e[0m\n", qstoc(c->title().text()),
 //               c->minYValue(), c->maxYValue() );
-        if(!isnan(c->minYValue()) && (c->minYValue() < yMin || yMin == yMax))
+        if(!std::isnan(c->minYValue()) && (c->minYValue() < yMin || yMin == yMax))
             tmp = c->minYValue(); /* to be able to make a valid test yMin == yMax below we need tmp */
-        if(!isnan(c->maxYValue()) && (c->maxYValue() > yMax || yMin == yMax))
+        if(!std::isnan(c->maxYValue()) && (c->maxYValue() > yMax || yMin == yMax))
             yMax = c->maxYValue();
         yMin = tmp; /* finally update yMin */
     }


### PR DESCRIPTION
While compaling on CentOS 7:
- g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44),
- Qt4, 
I got the following error:
```
rc/eplotlight/eplotlight_base.cpp: In member function ‘bool EPlotLightBase::adjustYScale(double, bool)’:
src/eplotlight/eplotlight_base.cpp:611:33: error: call of overloaded ‘isnan(double)’ is ambiguous
         if(!isnan(c->minYValue()) && (c->minYValue() < yMin || yMin == yMax))
                                 ^
src/eplotlight/eplotlight_base.cpp:611:33: note: candidates are:
In file included from /usr/include/features.h:375:0,
                 from /usr/include/c++/4.8.2/x86_64-redhat-linux/bits/os_defines.h:39,
                 from /usr/include/c++/4.8.2/x86_64-redhat-linux/bits/c++config.h:2097,
                 from /usr/include/c++/4.8.2/utility:68,
                 from /usr/include/c++/4.8.2/algorithm:60,
                 from /usr/include/QtCore/qglobal.h:68,
                 from /usr/include/qwt/qwt_global.h:13,
                 from /usr/include/qwt/qwt_plot.h:13,
                 from src/eplotlight/eplotlight_base.h:25,
                 from src/eplotlight/eplotlight_base.cpp:1:
/usr/include/bits/mathcalls.h:235:1: note: int isnan(double)
 __MATHDECL_1 (int,isnan,, (_Mdouble_ __value)) __attribute__ ((__const__));
 ^
In file included from /usr/include/c++/4.8.2/random:38:0,
                 from /usr/include/c++/4.8.2/bits/stl_algo.h:65,
                 from /usr/include/c++/4.8.2/algorithm:62,
                 from /usr/include/QtCore/qglobal.h:68,
                 from /usr/include/qwt/qwt_global.h:13,
                 from /usr/include/qwt/qwt_plot.h:13,
                 from src/eplotlight/eplotlight_base.h:25,
                 from src/eplotlight/eplotlight_base.cpp:1:
/usr/include/c++/4.8.2/cmath:626:3: note: constexpr bool std::isnan(long double)
   isnan(long double __x)
```

This patch fixes it.